### PR TITLE
Change raw pointers in GameObject vector to unique smart pointers

### DIFF
--- a/sfml-platformer/Character.cpp
+++ b/sfml-platformer/Character.cpp
@@ -114,8 +114,6 @@ sf::Vector2f Character::getStartPosition() const
 	return this->startPosition;
 }
 
-
-
 Character::Character()
 	: velocity(0, 0),
 	moveSpeed(0.0f),

--- a/sfml-platformer/Character.h
+++ b/sfml-platformer/Character.h
@@ -22,7 +22,7 @@ private:
 	sf::Vector2f startPosition;
 
 protected:
-	virtual void collisionControl(const sf::Time& time, std::vector<GameObject*>& gameObjects) = 0;
+	virtual void collisionControl(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects) = 0;
 	void collisionPlatform(const sf::FloatRect& hitBoxBounds, const sf::FloatRect& platformBounds);
 	void move(const sf::Vector2f& offset);
 	void flip();
@@ -45,7 +45,7 @@ public:
 	virtual ~Character();
 
 	void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
-	virtual void update(const sf::Time& time, std::vector<GameObject*>& gameObjects) = 0;
+	virtual void update(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects) = 0;
 
 	virtual void resetPosition();
 	virtual void resetLives();

--- a/sfml-platformer/Enemy.cpp
+++ b/sfml-platformer/Enemy.cpp
@@ -32,7 +32,7 @@ void Enemy::patrol(const sf::Time& time)
 	}
 }
 
-void Enemy::collisionControl(const sf::Time& time, std::vector<GameObject*>& gameObjects)
+void Enemy::collisionControl(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects)
 {
 	this->setGrounded(false);
 	float collisionOffset = 1.0f;
@@ -43,7 +43,7 @@ void Enemy::collisionControl(const sf::Time& time, std::vector<GameObject*>& gam
 	nextUpdateBounds.left += this->getVelocity().x * time.asSeconds();
 	nextUpdateBounds.top += this->getVelocity().y * time.asSeconds() + collisionOffset;
 
-	for (auto* i : gameObjects)
+	for (auto& i : gameObjects)
 	{
 		if (i != nullptr)
 		{
@@ -52,7 +52,7 @@ void Enemy::collisionControl(const sf::Time& time, std::vector<GameObject*>& gam
 			if (otherBounds.intersects(nextUpdateBounds))
 			{
 				GameObject* typePtr = nullptr;
-				typePtr = dynamic_cast<Platform*>(i);
+				typePtr = dynamic_cast<Platform*>(i.get());
 
 				if (typePtr != nullptr)
 				{
@@ -60,7 +60,7 @@ void Enemy::collisionControl(const sf::Time& time, std::vector<GameObject*>& gam
 				}
 				else
 				{
-					Player* playerPtr = dynamic_cast<Player*>(i);
+					Player* playerPtr = dynamic_cast<Player*>(i.get());
 
 					if (playerPtr != nullptr && !playerPtr->isHit())
 					{
@@ -84,7 +84,7 @@ Enemy::~Enemy()
 {
 }
 
-void Enemy::update(const sf::Time& time, std::vector<GameObject*>& gameObjects)
+void Enemy::update(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects)
 {
 	if (this->getStartPosition() == sf::Vector2f(0.0f, 0.0f))
 	{

--- a/sfml-platformer/Enemy.h
+++ b/sfml-platformer/Enemy.h
@@ -14,13 +14,13 @@ private:
 	bool reachedTarget;
 
 	void patrol(const sf::Time& time);
-	void collisionControl(const sf::Time& time, std::vector<GameObject*>& gameObjects) override;
+	void collisionControl(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects) override;
 
 public:
 	Enemy();
 	virtual ~Enemy();
 
-	void update(const sf::Time& time, std::vector<GameObject*>& gameObjects) override;
+	void update(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects) override;
 
 };
 

--- a/sfml-platformer/Level.cpp
+++ b/sfml-platformer/Level.cpp
@@ -12,24 +12,19 @@ Level::Level()
 
 Level::~Level()
 {
-	for (auto& i : gameObjects)
-	{
-		delete i;
-	}
 	gameObjects.clear();
 }
 
 void Level::update(const sf::Time& timeElapsedLastFrame)
 {
-	for (auto* i : gameObjects)
+	for (auto& i : gameObjects)
 	{
 		if (i == nullptr)
 		{
 			continue;
 		}
 
-		Character* characterPtr = nullptr;
-		characterPtr = dynamic_cast<Character*>(i);
+		Character* characterPtr = dynamic_cast<Character*>(i.get());
 
 		if (characterPtr != nullptr)
 		{
@@ -37,7 +32,7 @@ void Level::update(const sf::Time& timeElapsedLastFrame)
 		}
 
 		WinObject* winObjectPtr = nullptr;
-		winObjectPtr = dynamic_cast<WinObject*>(i);
+		winObjectPtr = dynamic_cast<WinObject*>(i.get());
 
 		if (winObjectPtr != nullptr)
 		{
@@ -49,14 +44,14 @@ void Level::update(const sf::Time& timeElapsedLastFrame)
 void Level::render(sf::RenderWindow& gameWindow)
 {
 	gameWindow.draw(backgroundSprite);
-	for (auto* object : gameObjects)
+	for (auto& object : gameObjects)
 	{
 		if (object == nullptr)
 		{
 			continue;
 		}
 		Character* characterPtr = nullptr;
-		characterPtr = dynamic_cast<Character*>(object);
+		characterPtr = dynamic_cast<Character*>(object.get());
 
 		if (characterPtr == nullptr || 
 			characterPtr != nullptr && 
@@ -70,10 +65,10 @@ void Level::render(sf::RenderWindow& gameWindow)
 void Level::load(const std::string& levelDataPath, const int column, const int row, const sf::Vector2i& gridSize)
 {
 	this->win = false;
-	for (auto& i : gameObjects)
-	{
-		delete i;
-	}
+	//for (auto& i : gameObjects)
+	//{
+	//	delete i;
+	//}
 	gameObjects.clear();
 
 	this->gameObjects.resize(column * row);
@@ -94,35 +89,33 @@ void Level::load(const std::string& levelDataPath, const int column, const int r
 	{
 		for (int j = 0; j < column; j++)
 		{
-			GameObject* gameObjectPtr = nullptr;
-			switch (this->levelArray.data()[levelIndex])
+			//GameObject* gameObjectPtr = nullptr;
+			std::unique_ptr<GameObject> gameObjectPtr = nullptr;
+			switch (this->levelArray.data()[levelIndex++])
 			{
 			case 0:
 				break;
 			case 1:
-				gameObjectPtr = new Platform;
+				gameObjectPtr = std::make_unique<Platform>();
 				break;
 			case 2:
-				gameObjectPtr = new WinObject;
+				gameObjectPtr = std::make_unique<WinObject>();
 				break;
 			case 3:
-				gameObjectPtr = new Player;
-				this->playerPtr = static_cast<Player*>(gameObjectPtr);
+				gameObjectPtr = std::make_unique<Player>();
+				this->playerPtr = static_cast<Player*>(gameObjectPtr.get());
 				playerPtr->setLevelLimitY(row * gridSize.y);
 				break;
 			case 4:
-				gameObjectPtr = new Enemy;
+				gameObjectPtr = std::make_unique<Enemy>();
 				break;
 			}
 			
 			if (gameObjectPtr != nullptr)
 			{
 				gameObjectPtr->setPosition(sf::Vector2f(j * gridSize.x, i * gridSize.y));
-				gameObjects.push_back(gameObjectPtr);
+				gameObjects.push_back(std::move(gameObjectPtr));
 			}
-			gameObjectPtr = nullptr;
-
-			levelIndex++;
 		}
 	}
 }
@@ -132,14 +125,14 @@ void Level::reset()
 	for (auto& i : gameObjects)
 	{
 		Character* characterPtr = nullptr;
-		characterPtr = dynamic_cast<Character*>(i);
+		characterPtr = dynamic_cast<Character*>(i.get());
 
 		if (characterPtr != nullptr)
 		{
 			characterPtr->resetPosition();
 		}
 		
-		characterPtr = dynamic_cast<Enemy*>(i);
+		characterPtr = dynamic_cast<Enemy*>(i.get());
 		if (characterPtr != nullptr)
 		{
 			characterPtr->resetLives();

--- a/sfml-platformer/Level.h
+++ b/sfml-platformer/Level.h
@@ -17,13 +17,15 @@
 class Level
 {
 private:
-	std::vector<GameObject*> gameObjects;
+	std::vector<std::unique_ptr<GameObject>> gameObjects;
 
 	Player* playerPtr;
 	
 	bool win;
 
 	std::array<int, 3200> levelArray;
+	// 	std::unique_ptr<int[]>levelArray;
+
 
 	sf::Sprite backgroundSprite;
 	sf::Texture backgroundTexture;

--- a/sfml-platformer/Player.cpp
+++ b/sfml-platformer/Player.cpp
@@ -67,7 +67,7 @@ void Player::playerControls(const sf::Time& time)
 	}
 }
 
-void Player::collisionControl(const sf::Time& time, std::vector<GameObject*>& gameObjects)
+void Player::collisionControl(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects)
 {
 	this->setGrounded(false);
 	float collisionOffset = 1.0f;
@@ -78,7 +78,7 @@ void Player::collisionControl(const sf::Time& time, std::vector<GameObject*>& ga
 	nextUpdateBounds.left += this->getVelocity().x * time.asSeconds();
 	nextUpdateBounds.top += this->getVelocity().y * time.asSeconds() + collisionOffset;
 
-	for (auto* i : gameObjects)
+	for (auto& i : gameObjects)
 	{
 		if (i == nullptr)
 		{
@@ -89,7 +89,7 @@ void Player::collisionControl(const sf::Time& time, std::vector<GameObject*>& ga
 		if (otherBounds.intersects(nextUpdateBounds))
 		{
 			GameObject* typePtr = nullptr;
-			typePtr = dynamic_cast<Platform*>(i);
+			typePtr = dynamic_cast<Platform*>(i.get());
 	
 			if (typePtr != nullptr)
 			{
@@ -97,7 +97,7 @@ void Player::collisionControl(const sf::Time& time, std::vector<GameObject*>& ga
 			}
 			else
 			{
-				typePtr = dynamic_cast<WinObject*>(i);
+				typePtr = dynamic_cast<WinObject*>(i.get());
 
 				if (typePtr != nullptr)
 				{
@@ -130,7 +130,7 @@ Player::~Player()
 	delete this->sword;
 }
 
-void Player::update(const sf::Time& time, std::vector<GameObject*>& gameObjects)
+void Player::update(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects)
 {
 	if (this->getStartPosition() == sf::Vector2f(0.0f, 0.0f))
 	{

--- a/sfml-platformer/Player.h
+++ b/sfml-platformer/Player.h
@@ -27,13 +27,13 @@ private:
 	float levelLimitY;
 
 	void playerControls(const sf::Time& time);
-	void collisionControl(const sf::Time& time, std::vector<GameObject*>& gameObjects) override;
+	void collisionControl(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects) override;
 
 public:
 	Player();
 	virtual ~Player();
 
-	void update(const sf::Time& time, std::vector<GameObject*>& gameObjects) override;
+	void update(const sf::Time& time, std::vector<std::unique_ptr<GameObject>>& gameObjects) override;
 
 	void setLevelLimitY(const float limit);
 };

--- a/sfml-platformer/Sword.cpp
+++ b/sfml-platformer/Sword.cpp
@@ -5,13 +5,8 @@ Sword::Sword()
 	attackTimer(0.0f),
 	lastFacingRight(true)
 {
-	//hitBox.setSize(sf::Vector2f(40.0f, 38.0f));
 	setHitBoxSize(sf::Vector2f(40.0f, 38.0f));
 	setHitBoxOrigin(sf::Vector2f(0.0f, this->getHitBox().getSize().y));
-	//hitBox.setOrigin(0.0f, this->hitBox.getSize().y);
-	//hitBox.setFillColor(sf::Color::Transparent);
-
-	//this->setPosition(sf::Vector2f(200.0f, 200.0f));
 }
 
 Sword::~Sword()
@@ -23,13 +18,13 @@ void Sword::draw(sf::RenderTarget& target, sf::RenderStates states) const
 	target.draw(this->getHitBox());
 }
 
-void Sword::update(const sf::Time& time, const bool facingRight, std::vector<GameObject*>& gameObjects)
+void Sword::update(const sf::Time& time, const bool facingRight, std::vector<std::unique_ptr<GameObject>>& gameObjects)
 {
 	if (attacking)
 	{
 		attackTimer += time.asSeconds();
 
-		for (auto* i : gameObjects)
+		for (auto& i : gameObjects)
 		{
 			if (i == nullptr)
 			{
@@ -38,7 +33,7 @@ void Sword::update(const sf::Time& time, const bool facingRight, std::vector<Gam
 
 			sf::FloatRect swordBounds = this->getHitBox().getGlobalBounds();
 			sf::FloatRect enemyBounds = i->getHitBox().getGlobalBounds();
-			Enemy* enemyPtr = dynamic_cast<Enemy*>(i);
+			Enemy* enemyPtr = dynamic_cast<Enemy*>(i.get());
 
 			if (enemyBounds.intersects(swordBounds) && enemyPtr != nullptr && enemyPtr->isAlive())
 			{

--- a/sfml-platformer/Sword.h
+++ b/sfml-platformer/Sword.h
@@ -18,7 +18,7 @@ public:
 	~Sword();
 
 	void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
-	void update(const sf::Time& time, const bool facingRight, std::vector<GameObject*>& gameObjects);
+	void update(const sf::Time& time, const bool facingRight, std::vector<std::unique_ptr<GameObject>>& gameObjects);
 
 	void attack();
 


### PR DESCRIPTION
Change the vector in Level that handles all the gameObjects to use smart pointers instead. Changed the update and collisionPlatform arguments to use a vector of unique_ptr<GameObject>&. 

Changed the dynamic casting loops that checks for type to auto& instead of auto*. Also had to add .get() to get the raw pointer when using dynamic cast.